### PR TITLE
 Allow user to specifying lat and long

### DIFF
--- a/lib/theme-flux.js
+++ b/lib/theme-flux.js
@@ -76,6 +76,37 @@ export default {
         },
       },
     },
+    geolocation: {
+      order: 3,
+      type: 'object',
+      properties: {
+        useGeolocationApi: {
+          order: 1,
+          title: 'Use Geolocation API',
+          description: 'Disable this if the location cannot be ascertained by the API',
+          type: 'boolean',
+          default: true,
+        },
+        specifiedLatitude: {
+          order: 2,
+          title: 'Specified Latitude',
+          description: 'Only used when API is disabled',
+          type: 'number',
+          default: 0,
+          minimum: -90,
+          maximum: 90,
+        },
+        specifiedLongitude: {
+          order: 3,
+          title: 'Specified Longitude',
+          description: 'Only used when API is disabled',
+          type: 'number',
+          default: 0,
+          minimum: -180,
+          maximum: 180,
+        },
+      },
+    },
   },
 
   activate() {
@@ -98,26 +129,40 @@ export default {
   },
 
   changeTheme() {
-    navigator.geolocation.getCurrentPosition(({ coords: { latitude, longitude } }) => {
-      const solar = new SolarCalc(new Date(), latitude, longitude);
+    if (atom.config.get('theme-flux.geolocation.useGeolocationApi')) {
+      navigator.geolocation.getCurrentPosition(
+        ({ coords: { latitude, longitude } }) => this.latLongCallback(latitude, longitude),
+        err => atom.notifications.addError('theme-flux: '+(err.message || 'unknown error encountered while getting geolocation')),
+        {timeout: 10000}
+      );
+    }
+    else {
+      this.latLongCallback(
+          atom.config.get('theme-flux.geolocation.specifiedLatitude'),
+          atom.config.get('theme-flux.geolocation.specifiedLongitude')
+      );
+    }
+  },
 
-      const isDay = this.isDay(solar);
-      if (isDay === this.wasDay) return;
+  latLongCallback(latitude, longitude) {
+    const solar = new SolarCalc(new Date(), latitude, longitude);
 
-      if (isDay) {
-        this.scheduleThemeUpdate([
-          atom.config.get('theme-flux.day.ui'),
-          atom.config.get('theme-flux.day.syntax'),
-        ]);
-      } else {
-        this.scheduleThemeUpdate([
-          atom.config.get('theme-flux.night.ui'),
-          atom.config.get('theme-flux.night.syntax'),
-        ]);
-      }
+    const isDay = this.isDay(solar);
+    if (isDay === this.wasDay) return;
 
-      this.wasDay = isDay;
-    });
+    if (isDay) {
+      this.scheduleThemeUpdate([
+        atom.config.get('theme-flux.day.ui'),
+        atom.config.get('theme-flux.day.syntax'),
+      ]);
+    } else {
+      this.scheduleThemeUpdate([
+        atom.config.get('theme-flux.night.ui'),
+        atom.config.get('theme-flux.night.syntax'),
+      ]);
+    }
+
+    this.wasDay = isDay;
   },
 
   scheduleThemeUpdate(themes) {


### PR DESCRIPTION
This was needed in cases where the `navigator.geolocation.getCurrentPosition` API was not working.